### PR TITLE
Add API Calls

### DIFF
--- a/superbloom.postman_collection.json
+++ b/superbloom.postman_collection.json
@@ -1,0 +1,182 @@
+{
+	"info": {
+		"_postman_id": "1f644b00-db1a-4cdb-809d-721d8f7a52c2",
+		"name": "BloomWatch - NASA API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "39449530"
+	},
+	"item": [
+		{
+			"name": "TEST: https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2025-10-03/250m/6/",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "sec-ch-ua",
+						"value": "\"Chromium\";v=\"140\", \"Not=A?Brand\";v=\"24\", \"Microsoft Edge\";v=\"140\""
+					},
+					{
+						"key": "sec-ch-ua-mobile",
+						"value": "?0"
+					},
+					{
+						"key": "sec-ch-ua-platform",
+						"value": "\"Windows\""
+					},
+					{
+						"key": "Upgrade-Insecure-Requests",
+						"value": "1"
+					},
+					{
+						"key": "User-Agent",
+						"value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0"
+					},
+					{
+						"key": "Accept",
+						"value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+					},
+					{
+						"key": "Sec-Fetch-Site",
+						"value": "none"
+					},
+					{
+						"key": "Sec-Fetch-Mode",
+						"value": "navigate"
+					},
+					{
+						"key": "Sec-Fetch-User",
+						"value": "?1"
+					},
+					{
+						"key": "Sec-Fetch-Dest",
+						"value": "document"
+					},
+					{
+						"key": "dnt",
+						"value": "1"
+					},
+					{
+						"key": "sec-gpc",
+						"value": "1"
+					},
+					{
+						"key": "host",
+						"value": "gibs.earthdata.nasa.gov"
+					}
+				],
+				"url": {
+					"raw": "{{baseURL}}/wmts/epsg4326/best/MODIS_Terra_CorrectedReflectance_TrueColor/default/2025-10-03/250m/6/13/36.jpg",
+					"host": [
+						"{{baseURL}}"
+					],
+					"path": [
+						"wmts",
+						"epsg4326",
+						"best",
+						"MODIS_Terra_CorrectedReflectance_TrueColor",
+						"default",
+						"2025-10-03",
+						"250m",
+						"6",
+						"13",
+						"36.jpg"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Earth Data",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "sec-ch-ua",
+						"value": "\"Chromium\";v=\"140\", \"Not=A?Brand\";v=\"24\", \"Microsoft Edge\";v=\"140\""
+					},
+					{
+						"key": "sec-ch-ua-mobile",
+						"value": "?0"
+					},
+					{
+						"key": "sec-ch-ua-platform",
+						"value": "\"Windows\""
+					},
+					{
+						"key": "Upgrade-Insecure-Requests",
+						"value": "1"
+					},
+					{
+						"key": "User-Agent",
+						"value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0"
+					},
+					{
+						"key": "Accept",
+						"value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+					},
+					{
+						"key": "Sec-Fetch-Site",
+						"value": "none"
+					},
+					{
+						"key": "Sec-Fetch-Mode",
+						"value": "navigate"
+					},
+					{
+						"key": "Sec-Fetch-User",
+						"value": "?1"
+					},
+					{
+						"key": "Sec-Fetch-Dest",
+						"value": "document"
+					},
+					{
+						"key": "dnt",
+						"value": "1"
+					},
+					{
+						"key": "sec-gpc",
+						"value": "1"
+					},
+					{
+						"key": "host",
+						"value": "gibs.earthdata.nasa.gov"
+					}
+				],
+				"url": {
+					"raw": "https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MODIS_Terra_NDVI_8Day/default/2025-04-15/250m/3/1/2.png",
+					"protocol": "https",
+					"host": [
+						"gibs",
+						"earthdata",
+						"nasa",
+						"gov"
+					],
+					"path": [
+						"wmts",
+						"epsg4326",
+						"best",
+						"MODIS_Terra_NDVI_8Day",
+						"default",
+						"2025-04-15",
+						"250m",
+						"3",
+						"1",
+						"2.png"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "baseURL",
+			"value": "",
+			"type": "default"
+		}
+	]
+}


### PR DESCRIPTION
- They are bundled in the JSON file and should be imported to Postman for usage there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Postman collection, “BloomWatch - NASA API,” with two ready-to-run GET requests: MODIS Terra True Color WMTS and MODIS Terra NDVI (8‑Day) WMTS.
- Documentation
  - Included a configurable base URL variable and example headers to simplify setup and testing.
  - Requests are provided without saved responses, allowing users to validate live API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->